### PR TITLE
Update belajar.md

### DIFF
--- a/belajar.md
+++ b/belajar.md
@@ -64,9 +64,6 @@ nav_order: 4
 - [KURSUS] [DataCamp - Python Courses](https://learn.datacamp.com/courses/tech:python)
 - [WEBSITE] [Real Python Tutorials](https://realpython.com)
 
-### Free Trial
-- [KURSUS] [DataCamp Access 2 Month Free](https://t.me/pythonID/155334)
-
 ## Latihan
 
 - [HackerRank](https://www.hackerrank.com/domains/python)


### PR DESCRIPTION
Menghapus Free Trial Datacamp dari Visual Studio Benefit, karena sekarang sudah tidak ada benefit 2 bulan Datacamp lagi yang ditawarkan dari setelah mendaftar di Visual Studio tersebut